### PR TITLE
Add link to github repo to rules.html

### DIFF
--- a/rules.html
+++ b/rules.html
@@ -178,5 +178,11 @@ body { max-width: 50em; margin-left: auto; margin-right: auto; }
 			<li>Yaakov</li>
 		</ul>
 
+                <h3>Earlier Revisions</h3>
+                
+                <p>Please note that this document is under 
+                <a href="https://github.com/perl-irc/perl-irc.github.io">revision control</a>. 
+                Previous versions and associated changes may be viewed at that link.</p>
+
 	</body>
 </html>


### PR DESCRIPTION
It's nice to be able to see how policies have been revised over time, so linking to the Github repo from the document seems to make sense.
