### PR TITLE
Add kiwiirc links on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@ _=&lt;DATA&gt;)){@camel1hum        p=split(//);}while(@dromeda
               57\156\056
 </tt></pre></td></tr></table>
 
-			<p>irc.perl.org - Port 6667</p>
-			<p>ssl.irc.perl.org - Port 7062</p>
+			<p><a href="https://kiwiirc.com/nextclient/#irc://irc.perl.org/#perl?nick=perl-guest-?">irc.perl.org</a> - Port 6667</p>
+			<p><a href="https://kiwiirc.com/nextclient/#ircs://ssl.irc.perl.org:7062/#perl?nick=perl-guest-?">ssl.irc.perl.org</a> - Port 7062</p>
 			<p><i>This network has a <a href="rules.html">Standard of Conduct</a></i></p>
 			<br />
 

--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@ _=&lt;DATA&gt;)){@camel1hum        p=split(//);}while(@dromeda
               57\156\056
 </tt></pre></td></tr></table>
 
-			<p><a href="https://kiwiirc.com/nextclient/#irc://irc.perl.org/#perl?nick=perl-guest-?">irc.perl.org</a> - Port 6667</p>
-			<p><a href="https://kiwiirc.com/nextclient/#ircs://ssl.irc.perl.org:7062/#perl?nick=perl-guest-?">ssl.irc.perl.org</a> - Port 7062</p>
+			<p><a href="https://kiwiirc.com/nextclient/#irc://irc.perl.org/#perl">irc.perl.org</a> - Port 6667</p>
+			<p><a href="https://kiwiirc.com/nextclient/#ircs://ssl.irc.perl.org:7062/#perl">ssl.irc.perl.org</a> - Port 7062</p>
 			<p><i>This network has a <a href="rules.html">Standard of Conduct</a></i></p>
 			<br />
 


### PR DESCRIPTION
The barrier to entry for a newbie going to irc.perl.org in their browser to actually interfacing the network would be significantly lowered by webchat links.